### PR TITLE
Change target speed based on joystick position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 # End of https://www.gitignore.io/api/gradle,java,eclipse,intellij
+
+train-tachograph/build

--- a/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
+++ b/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
@@ -22,7 +22,7 @@ public class TrainControllerImpl implements TrainController {
 			public void run() {
 				followSpeed();
 			}
-		}, 0, 1000);
+		}, 0, 500);
 
 	}
 

--- a/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
+++ b/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
@@ -2,11 +2,29 @@ package hu.bme.mit.train.controller;
 
 import hu.bme.mit.train.interfaces.TrainController;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 public class TrainControllerImpl implements TrainController {
 
 	private int step = 0;
 	private int referenceSpeed = 0;
 	private int speedLimit = 0;
+
+	private Timer timer;
+
+	public TrainControllerImpl() {
+
+		timer = new Timer();
+
+		timer.scheduleAtFixedRate(new TimerTask() {
+			@Override
+			public void run() {
+				followSpeed();
+			}
+		}, 0, 1000);
+
+	}
 
 	@Override
 	public void followSpeed() {
@@ -21,6 +39,7 @@ public class TrainControllerImpl implements TrainController {
 		}
 
 		enforceSpeedLimit();
+		
 	}
 
 	@Override
@@ -32,7 +51,6 @@ public class TrainControllerImpl implements TrainController {
 	public void setSpeedLimit(int speedLimit) {
 		this.speedLimit = speedLimit;
 		enforceSpeedLimit();
-		
 	}
 
 	private void enforceSpeedLimit() {


### PR DESCRIPTION
This PR adds the missing required functionality of accelerating or decelerating based on the state of the joystick.
It is being implemented by a Timer that is started when the system is created. This will need to be moved in the future when we have a more robust bootup system.